### PR TITLE
dr_spaam node is now a lifecycle node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ output/
 results/
 result_*/
 wandb
+install
+log

--- a/dr_spaam_ros/launch/dr_spaam_ros.launch.py
+++ b/dr_spaam_ros/launch/dr_spaam_ros.launch.py
@@ -2,6 +2,7 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
+from launch_ros.actions import LifecycleNode
 
 
 def generate_launch_description():
@@ -12,11 +13,13 @@ def generate_launch_description():
         'dr_spaam_ros.yaml'
         )
         
-    node=Node(
+    node=LifecycleNode(
         package = 'dr_spaam_ros',
         name = 'dr_spaam_ros_node',
         executable = 'dr_spaam_ros',
-        parameters = [config]
+        parameters = [config],
+        output='screen',
+        namespace=''
     )
     ld.add_action(node)
     return ld

--- a/dr_spaam_ros/package.xml
+++ b/dr_spaam_ros/package.xml
@@ -27,6 +27,7 @@
   <test_depend>python3-pytest</test_depend>
  
   <depend>rclpy</depend>
+  <depend>lifecycle_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
 </package>


### PR DESCRIPTION
This PR changes the dr_spaam node to a lifecycle node so that it can be started and stopped by an external process.
For a description of lifecycle nodes see https://github.com/ros2/demos/blob/iron/lifecycle/README.rst

Lifecycle nodes can in particular be managed from cmd line by using `ros2 lifecycle get /node_name` and `ros2 lifecycle set /node_name transition`